### PR TITLE
情報一覧機能

### DIFF
--- a/app/assets/stylesheets/restaurants/index.scss
+++ b/app/assets/stylesheets/restaurants/index.scss
@@ -116,5 +116,15 @@
 .main-content {
   padding: 20px 0 50px 0;
   background-color: $basic-gray;
+
+  &__paginations {
+    padding-top: 10px;
+    font-size: 25px;
+    
+    .pagination {
+      text-align: center;
+      
+    }
+  }
 }
 

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -2,6 +2,7 @@ class RestaurantsController < ApplicationController
   before_action :set_restaurant, only:[:show, :edit, :update]
 
   def index
+    @restaurants = Restaurant.includes(:images).page(params[:page]).per(5).order("created_at DESC")
   end
 
   def new

--- a/app/views/restaurants/index.html.haml
+++ b/app/views/restaurants/index.html.haml
@@ -39,11 +39,11 @@
 
 -# 店舗情報表示部分
 .main-content
-  = render partial: "shared/display"
-  = render partial: "shared/display"
-  = render partial: "shared/display"
-  = render partial: "shared/display"
-  = render partial: "shared/display"
+  - @restaurants.each do |restaurant|
+    = render partial: "shared/display", locals: {restaurant: restaurant}
+
+  .main-content__paginations
+    = paginate(@restaurants)
 
 -# フッター部分
 = render partial: "shared/footer"

--- a/app/views/restaurants/show.html.haml
+++ b/app/views/restaurants/show.html.haml
@@ -14,7 +14,10 @@
         .restaurant-info__images__section--caption
           ・お店の様子
         .restaurant-info__images__section--main
-          = image_tag "#{@restaurant.images.first.image}", class: "main-view", width: "350px", height: "200px"
+          - if @restaurant.images.present?
+            = image_tag "#{@restaurant.images.first.image}", class: "main-view", width: "350px", height: "200px"
+          - else
+            = image_tag "nodata.jpg", class: "main-view", width: "350px", height:"200px"
         .restaurant-info__images__section__sub
           .restaurant-info__images__section__sub--views
             -if @restaurant.images.second

--- a/app/views/shared/_display.html.haml
+++ b/app/views/shared/_display.html.haml
@@ -1,10 +1,13 @@
 .main-box
   .restaurant-box
-    = link_to restaurant_path(restaurant_url=1), class: "restaurant-box__info" do
+    = link_to restaurant_path(restaurant.id), class: "restaurant-box__info" do
       .restaurant-box__info--store
-        = image_tag "nodata.jpg", width: "584px", height:"300px"
+        - if restaurant.images.present?
+          = image_tag "#{restaurant.images.first.image}", width: "584px", height:"300px"
+        - else
+          = image_tag "nodata.jpg", width: "584px", height:"300px"
       .restaurant-box__info__detail
         .restaurant-box__info__detail--name
-          店名：オリオン食堂
+          店名： #{restaurant.name}
         .restaurant-box__info__detail--contributor
-          投稿者：まくらふみ
+          投稿者: #{restaurant.user.nickname}


### PR DESCRIPTION
## What
トップページに情報を表示する。

## Why
ユーザーがトップページから情報を見れるようにするため。

実装について
- restaurantsコントローラーにindexアクションの内容を記述。
- 部分テンプレート、displayの表示内容にDB情報を使用できるようeach文を追加。
- 部分テンプレート、displayのrestaurant_pathの付加情報をurlからidへ変更。
- 各種表示内容をDBに保存された情報に変更。
- imageがない場合エラーが出るため、エラーが起きないようにdisplayとshowにif文追加。
- gem kaminariを使用し、ページネーションを実装。cssを追加。