### PR TITLE
店舗情報削除機能

### DIFF
--- a/app/assets/stylesheets/restaurants/index.scss
+++ b/app/assets/stylesheets/restaurants/index.scss
@@ -123,7 +123,6 @@
     
     .pagination {
       text-align: center;
-      
     }
   }
 }

--- a/app/assets/stylesheets/restaurants/new.scss
+++ b/app/assets/stylesheets/restaurants/new.scss
@@ -331,5 +331,19 @@
       font-size: 20px;
       color: white;
     }
+
+    &--return {
+      margin: 0 auto;
+      height: 40px;
+      width: 200px;
+      border: 2px solid $basic-gray;
+      background-color: $basic-gray;
+      font-size: 20px;
+      
+      .return-btn {
+        text-decoration: none;
+        color: white;
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/restaurants/show.scss
+++ b/app/assets/stylesheets/restaurants/show.scss
@@ -82,7 +82,7 @@
     &__box {
       margin: 0 auto;
       width: 700px;
-      font-size: 25px;
+      font-size: 20px;
 
       th {
         width: 220px;

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -1,5 +1,5 @@
 class RestaurantsController < ApplicationController
-  before_action :set_restaurant, only:[:show, :edit, :update]
+  before_action :set_restaurant, only:[:show, :edit, :update, :destroy]
 
   def index
     @restaurants = Restaurant.includes(:images).page(params[:page]).per(5).order("created_at DESC")
@@ -31,6 +31,14 @@ class RestaurantsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+      if @restaurant.destroy
+        redirect_to root_path
+      else
+        redirect_to restaurant_path
+      end
   end
 
   private

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -4,7 +4,7 @@ class Restaurant < ApplicationRecord
     belongs_to_active_hash :cuisine
 
   belongs_to :user
-  has_many :images
+  has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true
 
   validates :name, presence: true

--- a/app/views/restaurants/edit.html.haml
+++ b/app/views/restaurants/edit.html.haml
@@ -146,7 +146,7 @@
           .restaurant-input__btn--post
             = f.submit "変更する", class: "submit-btn"
           .restaurant-input__btn--return
-            = link_to root_path do
+            = link_to root_path, class: "return-btn" do
               戻る
 
 -# フッター部分

--- a/app/views/restaurants/new.html.haml
+++ b/app/views/restaurants/new.html.haml
@@ -143,7 +143,7 @@
           .restaurant-input__btn--post
             = f.submit "投稿する", class: "submit-btn"
           .restaurant-input__btn--return
-            = link_to root_path do
+            = link_to root_path, class: "return-btn" do
               戻る
 
 -# フッター部分

--- a/app/views/restaurants/show.html.haml
+++ b/app/views/restaurants/show.html.haml
@@ -98,8 +98,9 @@
                 .restaurant-info__action__btns__edit--text
                   編集する
             .restaurant-info__action__btns__delete
-              .restaurant-info__action__btns__delete--text
-                削除する
+              = link_to restaurant_path(@restaurant), class: "show-link", method: :delete do
+                .restaurant-info__action__btns__delete--text
+                  削除する
             .restaurant-info__action__btns__return
               = link_to root_path, class: "show-link" do
                 .restaurant-info__action__btns__return--text


### PR DESCRIPTION
## What
店舗情報の削除機能の実装。

## Why
ユーザーに必要がなくなった情報を削除してもらうため。

実装について
- restaurantコントローラーにdestroyアクションを追加。
- set_restaurantにdestroyを追加。
- showビューの削除ボタンにpathとdeleteメソッドを追加。
- restaurantモデル、imagesアソシエーションにdependent::destroyメソッドを追加。

その他修正
- new・editページの戻るボタンにcssを追加。
- showページの文字サイズ調整。