### PR TITLE
ユーザー情報変更機能

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,12 +11,12 @@
 @import "./shared/display";
 @import "./shared/footer";
 @import "./shared/menuindex";
+@import "./users/edit";
 @import "./users/show";
 @import "./restaurants/edit";
 @import "./restaurants/index";
 @import "./restaurants/new";
 @import "./restaurants/show";
-
 
 *{
   box-sizing: border-box;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@
 @import "./devise/new_account";
 @import "./devise/login";
 @import "./devise/links";
+@import "./devise/edit";
 @import "./shared/header";
 @import "./shared/display";
 @import "./shared/footer";

--- a/app/assets/stylesheets/devise/_links.scss
+++ b/app/assets/stylesheets/devise/_links.scss
@@ -7,6 +7,7 @@
     }
 }
 
+// ログインページ用アカウントページ移動ボタン
 .loginpage-signup {
   @include account-link-btn;
 

--- a/app/assets/stylesheets/devise/edit.scss
+++ b/app/assets/stylesheets/devise/edit.scss
@@ -1,0 +1,61 @@
+.edit {
+  padding-top: 30px;
+
+  &__box {
+    @include box-size;
+
+  // 編集ページタイトル部分
+    &__caption {
+      @include caption-box;
+
+      &--title {
+        @include caption-font;
+        border-bottom: 4px solid greenyellow;
+      }
+
+      &--detail {
+        @include detail-set;
+      }
+
+    // 戻るボタン部分
+      &__extra {
+        margin-top: 50px;
+
+        &--return {
+          margin-top: 30px;
+        }
+      }
+    }
+
+  // 編集情報入力部分
+    &__form {
+      width: 50%;
+      float: right;
+      padding: 20px 0 0 70px;
+
+      &--field {
+        margin-bottom: 10px;
+
+        .field-name {
+          @include name-caption;
+        }
+
+        .form-input {
+          @include input-bar;
+        }
+      }
+
+    // 編集確定ボタン
+      &--actions {
+        margin-top: 20px;
+        text-align: center;
+
+        .action-btn {
+          @include submit-btn;
+          border: 3px solid greenyellow;
+          background-color: greenyellow;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/users/edit.scss
+++ b/app/assets/stylesheets/users/edit.scss
@@ -1,0 +1,63 @@
+.name-edit {
+  padding-top: 30px;
+
+  &__box {
+    height: 450px;
+    width: 600px;
+    border: solid 1px black;
+    margin: 0 auto;
+    padding: 25px;
+
+    &__caption {
+      padding-left: 10px;
+
+      &--title {
+        @include caption-font;
+        border-bottom: 4px solid orangered;
+      }
+
+      &--detail {
+        @include detail-set;
+      }
+    }
+
+    &__form {
+      margin: 40px 0 0 70px;
+
+      &--field {
+        margin-bottom: 10px;
+
+        .field-name {
+          @include name-caption;
+        }
+
+        .form-input {
+          @include input-bar;
+        }
+      }
+
+      &--actions {
+        margin: 20px 0 0 40px;
+
+        .action-btn--patch {
+          @include submit-btn;
+          border: 3px solid orangered;
+          background-color: orangered;
+        }
+      }
+
+      &--return {
+        margin: 20px 0 0 150px;
+        
+
+        .action-btn--return {
+          font-size: 25px;
+          text-decoration: none;
+          color: white;
+          border: 3px solid $basic-gray;
+          background-color: $basic-gray;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/users/show.scss
+++ b/app/assets/stylesheets/users/show.scss
@@ -16,12 +16,12 @@
 
       .link-none {
         text-decoration: none;
-        color: white;
+        color: black;
       }
 
       &__btnbox {
         width: 220px;
-        height: 170px;
+        height: 240px;
         background-color: white;
         padding: 10px 0 0 10px;
         border-radius: 5px;
@@ -36,7 +36,7 @@
           }
         }
 
-        &__edit {
+        &__nickname {
           @include mypage-btn;
           border: 2px solid orangered;
           background-color: orangered;
@@ -44,9 +44,22 @@
           padding-left: 5px;
           display: flex;
           margin-bottom: 20px;
+
+          &--icon {
+            margin-right: 7px;
+          }
+        }
+
+        &__edit {
+          @include mypage-btn;
+          border: 2px solid greenyellow;
+          background-color: greenyellow;
+          margin-right: 20px;
+          padding-left: 5px;
+          display: flex;
+          margin-bottom: 20px;
   
           &--icon {
-            color: white;
             margin-right: 7px;
           }
         }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,15 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_user, only:[:show]
+  before_action :set_user, only:[:show, :edit, :update]
 
   def show
     @restaurants = Restaurant.where(user_id: current_user.id).page(params[:page]).per(3).order("created_at DESC")
+  end
+
+  def edit
+  end
+
+  def update
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,11 +10,20 @@ class UsersController < ApplicationController
   end
 
   def update
+    if current_user.update(user_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
   end
 
   private
 
    def set_user
     @user = current_user
+   end
+
+   def user_params
+    params.require(:user).permit(:nickname)
    end
 end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,36 +1,52 @@
-%h2
-  Edit #{resource_name.to_s.humanize}
-= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    %div
-      Currently waiting confirmation for: #{resource.unconfirmed_email}
-  .field
-    = f.label :password
-    %i (leave blank if you don't want to change it)
-    %br/
-    = f.password_field :password, autocomplete: "new-password"
-    - if @minimum_password_length
-      %br/
-      %em
-        = @minimum_password_length
-        characters minimum
-  .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .field
-    = f.label :current_password
-    %i (we need your current password to confirm your changes)
-    %br/
-    = f.password_field :current_password, autocomplete: "current-password"
-  .actions
-    = f.submit "Update"
-%h3 Cancel my account
-%p
-  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
-= link_to "Back", :back
+= render partial: "shared/header"
+
+= render "devise/shared/error_messages", resource: resource
+.edit
+  .edit__box
+    .edit__box__caption
+      %h2.edit__box__caption--title
+        Edit #{resource_name.to_s.humanize}
+      .edit__box__caption--detail
+        ユーザー情報編集
+      %h3.eidt__box__caption__return
+        Cancel my account
+        %p
+        Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
+        = link_to "Back", :back
+
+    .edit__box__form
+      = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+        
+        .edit__box__form--.field
+          = f.label :email, class: "field-name"
+          %br/
+          = f.email_field :email, autofocus: true, autocomplete: "email", class: "form-input"
+        - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+          %div
+            Currently waiting confirmation for: #{resource.unconfirmed_email}
+        
+        .edit__box__form--.field
+          = f.label :password, class: "field-name"
+          %i (leave blank if you don't want to change it)
+          %br/
+          = f.password_field :password, autocomplete: "new-password", class: "form-input", placeholder: "新しいパスワードを入力"
+          - if @minimum_password_length
+            %br/
+            %em
+              = @minimum_password_length
+              characters minimum
+        
+        .edit__box__form--.field
+          = f.label :password_confirmation, class: "field-name"
+          %br/
+          = f.password_field :password_confirmation, autocomplete: "new-password", class: "form-input"
+        
+        .edit__box__form--.field
+          = f.label :current_password, class: "field-name"
+          %i (we need your current password to confirm your changes)
+          %br/
+          = f.password_field :current_password, autocomplete: "current-password", class: "form-input", placeholder: "以前のパスワードを入力"
+  
+        .edit__box__form--actions
+          = f.submit "Update"
+

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -8,11 +8,12 @@
         Edit #{resource_name.to_s.humanize}
       .edit__box__caption--detail
         ユーザー情報編集
-      %h3.eidt__box__caption__return
+      %h3.edit__box__caption__extra
         Cancel my account
         %p
         Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
-        = link_to "Back", :back
+        .edit__box__caption__extra--return
+          = link_to "Back", :back
 
     .edit__box__form
       = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,6 +1,6 @@
 = render partial: "shared/header"
-
 = render "devise/shared/error_messages", resource: resource
+
 .edit
   .edit__box
     .edit__box__caption
@@ -17,7 +17,7 @@
     .edit__box__form
       = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
         
-        .edit__box__form--.field
+        .edit__box__form--field
           = f.label :email, class: "field-name"
           %br/
           = f.email_field :email, autofocus: true, autocomplete: "email", class: "form-input"
@@ -25,7 +25,7 @@
           %div
             Currently waiting confirmation for: #{resource.unconfirmed_email}
         
-        .edit__box__form--.field
+        .edit__box__form--field
           = f.label :password, class: "field-name"
           %i (leave blank if you don't want to change it)
           %br/
@@ -36,17 +36,17 @@
               = @minimum_password_length
               characters minimum
         
-        .edit__box__form--.field
+        .edit__box__form--field
           = f.label :password_confirmation, class: "field-name"
           %br/
           = f.password_field :password_confirmation, autocomplete: "new-password", class: "form-input"
         
-        .edit__box__form--.field
+        .edit__box__form--field
           = f.label :current_password, class: "field-name"
           %i (we need your current password to confirm your changes)
           %br/
-          = f.password_field :current_password, autocomplete: "current-password", class: "form-input", placeholder: "以前のパスワードを入力"
+          = f.password_field :current_password, autocomplete: "current-password", class: "form-input", placeholder: "変更前のパスワードを入力"
   
         .edit__box__form--actions
-          = f.submit "Update"
+          = f.submit "Update", class: "action-btn"
 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -19,7 +19,7 @@
         = render "devise/shared/error_messages", resource: resource
 
         .signup__box__form--field
-          = f.label :nickname, class: "field-name"
+          = f.label :nickname, "ニックネーム", class: "field-name"
           %br/
           = f.text_field :nickname, class: "form-input", placeholder: "ニックネームを入力"
 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,4 +1,4 @@
-= render "shared/header"
+= render partial: "shared/header"
 
 .signup
   .signup__box

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,4 +1,4 @@
-= render "shared/header" 
+= render partial: "shared/header" 
 
 .login
   .login__box

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,0 +1,24 @@
+= render partial: "shared/header"
+
+.name-edit
+  .name-edit__box
+    .name-edit__box__caption
+      .name-edit__box__caption--title
+        Nickname Edit
+      .name-edit__box__caption--detail
+        ニックネーム編集
+
+    .name-edit__box__form
+      = form_for(current_user) do |f|
+
+        .name-edit__box__form--field
+          = f.label :nickanme, "ニックネーム", class: "field-name"
+          %br
+          = f.text_field :nickname, class: "form-input", placeholder: "新しいニックネームを入力"
+
+        .name-edit__box__form--actions
+          = f.submit "Update", class: "action-btn--patch"
+        
+        .name-edit__box__form--return
+          = link_to user_path, class: "action-btn--return" do
+            戻る

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -18,7 +18,7 @@
           .mypage-index__wapper__left__btnbox__nickname--icon
             = fa_icon 'edit'
           .mypage-index__wapper__left__btnbox__nickname--text
-            = link_to "#", class: "link-none" do
+            = link_to edit_user_path(current_user.id), class: "link-none" do
               ニックネーム変更
         .mypage-index__wapper__left__btnbox__edit
           .mypage-index__wapper__left__btnbox__edit--icon

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -18,7 +18,7 @@
           .mypage-index__wapper__left__btnbox__edit--icon
             = fa_icon 'cog'
           .mypage-index__wapper__left__btnbox__edit--text
-            = link_to "#", class: "link-none" do
+            = link_to edit_user_registration_path(current_user.id), class: "link-none" do
               ユーザー情報変更
         .mypage-index__wapper__left__btnbox--logout
           = link_to destroy_user_session_path, class: "link-none", method: :delete do

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -14,6 +14,12 @@
         .mypage-index__wapper__left__btnbox__menu
           .mypage-index__wapper__left__btnbox__menu--text
             ・メニュー
+        .mypage-index__wapper__left__btnbox__nickname
+          .mypage-index__wapper__left__btnbox__nickname--icon
+            = fa_icon 'edit'
+          .mypage-index__wapper__left__btnbox__nickname--text
+            = link_to "#", class: "link-none" do
+              ニックネーム変更
         .mypage-index__wapper__left__btnbox__edit
           .mypage-index__wapper__left__btnbox__edit--icon
             = fa_icon 'cog'

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Kodoguru
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
+    config.i18n.default_locale = :ja
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,142 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザ
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントは凍結されています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: あなたのメール変更（%{email}）のお知らせいたします。
+        subject: メール変更完了。
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されたことを通知します。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントの凍結解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか?
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか?
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントが凍結されているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか?
+        didn_t_receive_unlock_instructions: アカウントの凍結解除方法のメールを受け取っていませんか?
+        forgot_your_password: パスワードを忘れましたか?
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントの凍結解除方法を再送する
+      send_instructions: アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントを凍結解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: は凍結されていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,207 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,5 @@ Rails.application.routes.draw do
   root "restaurants#index"
   resources :restaurants
 
-  resources :users, only: :show
+  resources :users, only: [:show, :edit, :update]
 end


### PR DESCRIPTION
## What
ユーザー情報の変更機能を作成する。

## Why
ユーザーが自身の情報を編集してもらうため。

実装について
- ユーザー情報（Eメール、パスワード）編集用のページを編集。
- ユーザー情報（Eメール、パスワード）編集用ページのcssファイルを追加。内容記述。
- マイページ、ユーザー情報変更ボタンに画面遷移用のパスを記述。
- nickname変更用ページを作成。クラス記述。
- nickname変更用ページのcssファイルを作成。内容記述。
- ルートのusersにeditとupdateを追加。
- users_controllerにeditとupdateアクションを記述。privateにupdatem用paramsを設定。
- マイページにニックネーム変更ページ遷移用ボタンを作成。パスを追記。

その他実装
- 各メッセージを日本語化。
- nicknameキャプション部分を日本語化。
-
-