### PR TITLE
メニュー投稿機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@
 |Column|Type|Options|
 |------|----|-------|
 |image|string||
-|restaurant_id|integer|null: false, foreign_key: true|
+|restaurant_id|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :restaurant
@@ -90,11 +90,12 @@
 ### menusテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|string|null: false|
+|menuname|string|null: false|
 |photo|string||
 |price|integer|null: false|
 |detail|string||
-|restaurant_id|integer|null: false, foreign_key: true|
+|restaurant_id|references|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: ture|
 
 ### Association
 - belongs_to :restaurant

--- a/app/assets/javascripts/menu.js
+++ b/app/assets/javascripts/menu.js
@@ -1,0 +1,46 @@
+$(function() {
+  const view_box = $('#photo-preview');
+
+  $('.js-file__menu').on('change', function() {
+    const fileprop = $(this).prop('files')[0]
+          find_img = $(this).next('img')
+          fileRdr = new FileReader();
+
+    if(find_img.length){
+      find_img.nextAll().remove();
+      find_img.remove();
+    }
+
+    const img = '<img width="550px" height= "250px" alt="" class="img_view">';
+ 
+    view_box.append(img);
+     
+    fileRdr.onload = function() {    
+      view_box.find('img').attr('src', fileRdr.result);
+    }
+    fileRdr.readAsDataURL(fileprop);  
+  });
+});
+
+
+// $(function() {
+//   const buildImg = (url)=> {
+//     const html = `<div class="preview">
+//     <img src="${url}" width="100px" height="100px"></br>
+//   </div>`;
+//     return html;
+//   }
+
+//   $('.js-file__menu').on('change', '.js-file__menu', function(e) {
+//     // ファイルのブラウザ上でのURLを取得する
+//     const file = e.target.files[0];
+//     const blobUrl = window.URL.createObjectURL(file);
+
+//     // 該当indexを持つimgタグがあれば取得して変数imgに入れる（画像変更の処理）
+//     if (img = $(`img`)[0]) {
+//       img.setAttribute('src', blobUrl);
+//     } else { //新規画像追加の処理
+//       $('#previews').append(buildImg(blobUrl));
+//     }
+//   });
+// });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@
 @import "./devise/login";
 @import "./devise/links";
 @import "./devise/edit";
+@import "./menus/new";
 @import "./shared/header";
 @import "./shared/display";
 @import "./shared/footer";

--- a/app/assets/stylesheets/menus/new.scss
+++ b/app/assets/stylesheets/menus/new.scss
@@ -66,6 +66,10 @@
       width: 600px;
       background-color: $basic-gray;
     }
+
+    #photo-preview {
+      padding-left: 25px;
+    }
   }
 
   &__menuname {
@@ -104,6 +108,7 @@
     }
   }
 
+  // メニュー投稿ボタン部分
   &__btn {
     padding-top: 10px;
     text-align: center;
@@ -124,8 +129,4 @@
       @include return-text;
     }
   }
-}
-
-#photo-preview {
-  padding-left: 25px;
 }

--- a/app/assets/stylesheets/menus/new.scss
+++ b/app/assets/stylesheets/menus/new.scss
@@ -125,3 +125,7 @@
     }
   }
 }
+
+#photo-preview {
+  padding-left: 25px;
+}

--- a/app/assets/stylesheets/menus/new.scss
+++ b/app/assets/stylesheets/menus/new.scss
@@ -1,0 +1,127 @@
+// メニュー新規投稿背景部分
+.menu {
+  background-color: wheat;
+  padding: 15px 0 25px 0;
+}
+
+// メニュー新規投稿入力部分全体
+.menu-page {
+  width: 800px;
+  background-color: white;
+  margin: 0 auto;
+  padding: 10px 0;
+}
+
+// メニュー新規投稿入力タイトル部分
+.menu-form {
+  height: 50px;
+  text-align: center;
+  border-bottom: 5px solid $basic-gray;
+
+  &__title {
+    padding: 0 10px;
+    font-size: 30px;
+    font-weight: bold;
+  }
+}
+
+// メニュー新規投稿入力フィールド
+.menu-input {
+  padding: 20px 0;
+
+  // 必須・任意見出し
+  .input-required {
+    @include required-exterior;
+  }
+
+  .input-any {
+    @include any-exterior;
+  }
+
+  // テキストエリア部分
+  .text-field__form {
+    @include text-form;
+  }
+
+  .text-area__form {
+    @include text-area-box;
+  }
+
+  // メニュー画像投稿部分
+  &__photobox {
+    padding-bottom: 20px;
+
+    &--title {
+      @include new-actionform-title;
+    }
+
+    &--detail {
+      font-size: 15px;
+      padding: 0 0 10px 50px;
+    }
+
+    &__main {
+      margin: 0 auto;
+      height: 300px;
+      width: 600px;
+      background-color: $basic-gray;
+    }
+  }
+
+  &__menuname {
+    padding: 20px 0;
+
+    &--title {
+      @include new-actionform-title;
+    }
+
+    &--field {
+      padding-left: 95px;
+    }
+  }
+
+  &__price {
+    padding: 20px 0;
+
+    &--title {
+      @include new-actionform-title;
+    }
+
+    &--field {
+      padding-left: 95px;
+    }
+  }
+
+  &__details {
+    padding: 20px 0;
+
+    &--title {
+      @include new-actionform-title;
+    }
+
+    &--field {
+      padding-left: 95px;
+    }
+  }
+
+  &__btn {
+    padding-top: 10px;
+    text-align: center;
+
+    &--submit {
+      padding-bottom: 10px;
+    }
+
+    .submit-btn {
+      @include submit-exterior;
+    }
+
+    &--return {
+      @include return-exterior;
+    }
+
+    .return-btn {
+      @include return-text;
+    }
+  }
+}

--- a/app/assets/stylesheets/mixins/_mixin.scss
+++ b/app/assets/stylesheets/mixins/_mixin.scss
@@ -81,13 +81,74 @@
   color: blue
 }
 
-// 店舗情報登録ページ用
+// 全新規投稿・編集ページ共通部分
 @mixin new-actionform-title() {
   padding-left: 30px;
   font-size: 18px;
   font-weight: bold;
   margin-bottom: 5px;
   display: flex;
+}
+
+@mixin required-exterior() {
+  border: solid 1px orangered;
+  background-color: orangered;
+  border-radius: 3px;
+  height: 30px;
+  width: 50px;
+  text-align: center;
+  color: white;
+  margin-left: 10px;
+}
+
+@mixin any-exterior() {
+  border: solid 1px gray;
+  background-color: gray;
+  border-radius: 3px;
+  height: 30px;
+  width: 50px;
+  text-align: center;
+  color: white;
+  margin-left: 10px;
+}
+
+@mixin text-form() {
+  height: 40px;
+  width: 600px;
+  border: 2px solid $basic-gray;
+  border-radius: 3px;
+  padding: 3px;
+}
+
+@mixin text-area-box() {
+  height: 100px;
+  width: 600px;
+  border: 2px solid $basic-gray;
+  border-radius: 3px;
+  padding: 3px;
+}
+
+@mixin submit-exterior() {
+  height: 40px;
+  width: 200px;
+  border: 2px solid orangered;
+  background-color: orangered;
+  font-size: 20px;
+  color: white;
+}
+
+@mixin return-exterior() {
+  margin: 0 auto;
+  height: 40px;
+  width: 200px;
+  border: 2px solid $basic-gray;
+  background-color: $basic-gray;
+  font-size: 20px;
+}
+
+@mixin return-text() {
+  text-decoration: none;
+  color: white;
 }
 
 // 店舗情報編集ページ用

--- a/app/assets/stylesheets/restaurants/new.scss
+++ b/app/assets/stylesheets/restaurants/new.scss
@@ -89,42 +89,20 @@
 
   // 必須・任意見出し
   .input-required {
-    border: solid 1px orangered;
-    background-color: orangered;
-    border-radius: 3px;
-    height: 30px;
-    width: 50px;
-    text-align: center;
-    color: white;
-    margin-left: 10px;
+    @include required-exterior;
   }
 
   .input-any {
-    border: solid 1px gray;
-    background-color: gray;
-    border-radius: 3px;
-    height: 30px;
-    width: 50px;
-    text-align: center;
-    color: white;
-    margin-left: 10px;
+    @include any-exterior;
   }
 
   // 投稿フォームバー・セレクトボックス用
   .text-field__form {
-    height: 40px;
-    width: 600px;
-    border: 2px solid $basic-gray;
-    border-radius: 3px;
-    padding: 3px;
+    @include text-form;
   }
 
   .text-area__form {
-    height: 100px;
-    width: 600px;
-    border: 2px solid $basic-gray;
-    border-radius: 3px;
-    padding: 3px;
+    @include text-area-box;
   }
 
   .select-field__form {
@@ -324,25 +302,14 @@
     }
 
     .submit-btn {
-      height: 40px;
-      width: 200px;
-      border: 2px solid orangered;
-      background-color: orangered;
-      font-size: 20px;
-      color: white;
+      @include submit-exterior;
     }
 
     &--return {
-      margin: 0 auto;
-      height: 40px;
-      width: 200px;
-      border: 2px solid $basic-gray;
-      background-color: $basic-gray;
-      font-size: 20px;
+      @include return-exterior;
       
       .return-btn {
-        text-decoration: none;
-        color: white;
+        @include return-text;
       }
     }
   }

--- a/app/assets/stylesheets/restaurants/show.scss
+++ b/app/assets/stylesheets/restaurants/show.scss
@@ -125,10 +125,10 @@
 
   // 編集・削除・戻るボタン部分
   &__action {
-    padding: 10px 0;
     @include body-bottom-solid;
 
     &__btns {
+      padding: 10px 0;
 
       &__edit {
         @include show-page-btns;

--- a/app/assets/stylesheets/users/edit.scss
+++ b/app/assets/stylesheets/users/edit.scss
@@ -47,15 +47,18 @@
       }
 
       &--return {
-        margin: 20px 0 0 155px;
-        
+        height: 50px;
+        width: 300px;
+        border: 3px solid $basic-gray;
+        background-color: $basic-gray;
+        text-align: center;
+        margin: 10px 0 0 40px;
 
         .action-btn--return {
           font-size: 25px;
           text-decoration: none;
           color: white;
-          border: 3px solid $basic-gray;
-          background-color: $basic-gray;
+          
         }
       }
     }

--- a/app/assets/stylesheets/users/edit.scss
+++ b/app/assets/stylesheets/users/edit.scss
@@ -47,7 +47,7 @@
       }
 
       &--return {
-        margin: 20px 0 0 150px;
+        margin: 20px 0 0 155px;
         
 
         .action-btn--return {

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,0 +1,2 @@
+class MenusController < ApplicationController
+end

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,6 +1,22 @@
 class MenusController < ApplicationController
 
   def new
+    @restaurant = Restaurant.find(params[:restaurant_id])
     @menu = Menu.new
   end
+
+  def create
+    @menu = Menu.new(menu_params)
+    if @menu.save
+      redirect_to root_path
+    else
+      render :new
+    end
+  end
+
+  private
+
+    def menu_params
+      params.require(:menu).permit(:menuname, :photo, :price, :detail).merge(user_id: current_user.id, restaurant_id: params[:restaurant_id])
+    end
 end

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,2 +1,6 @@
 class MenusController < ApplicationController
+
+  def new
+    @menu = Menu.new
+  end
 end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,0 +1,2 @@
+class Menu < ApplicationRecord
+end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,2 +1,7 @@
 class Menu < ApplicationRecord
+  belongs_to :user
+  belongs_to :restaurant
+
+  validates :menuname, presence: true
+  validates :price, presence: true
 end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -2,6 +2,8 @@ class Menu < ApplicationRecord
   belongs_to :user
   belongs_to :restaurant
 
+  mount_uploader :photo, ImageUploader
+
   validates :menuname, presence: true
   validates :price, presence: true
 end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -6,6 +6,7 @@ class Restaurant < ApplicationRecord
   belongs_to :user
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true
+  has_many :menus, dependent: :destroy
 
   validates :name, presence: true
   validates :cuisine_id, presence: true

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -7,6 +7,7 @@ class Restaurant < ApplicationRecord
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true
   has_many :menus, dependent: :destroy
+  accepts_nested_attributes_for :menus
 
   validates :name, presence: true
   validates :cuisine_id, presence: true

--- a/app/views/menus/_form.html.haml
+++ b/app/views/menus/_form.html.haml
@@ -1,0 +1,54 @@
+.menu
+  .menu-page
+    .menu-form
+      .menu-form__title
+        メニュー情報入力
+    .menu-input
+      = form_with model: @menu, url: restaurants_menus_create_restaurant_menus_path ,mehtod: :post, action: :create, local: true do |f|
+
+        -# 画像投稿部分
+        .menu-input__photobox
+          .menu-input__photobox--title
+            ・メニュー写真（１枚のみ）
+            .input-required
+              必須
+          .menu-input__photobox--detail
+            ※サムネイルにも使われます
+          .menu-input__photobox__main
+            #photo-field
+              #photo-preview
+                - if @menu.persisted?
+                  = image_tag @menu.photo.url, width: "100px", height: "100px"
+                = f.file_field :photo, class: "js-file__menu"
+
+        -# 情報入力部分
+        .menu-input__menuname
+          .menu-input__menuname--title
+            ・メニュー名
+            .input-required
+              必須
+          .menu-input__menuname--field
+            = f.text_field :menuname, class: "text-field__form", placeholder: "例：生姜焼き定食"
+        
+        .menu-input__price
+          .menu-input__price--title
+            ・商品価格
+            .input-required
+              必須
+          .menu-input__price--field
+            = f.text_field :price, class: "text-field__form", placeholder: "例：1000円"
+
+        .menu-input__details
+          .menu-input__details--title
+            ・おすすめポイント
+            .input-any
+              任意
+          .menu-input__details--field
+            = f.text_area :detail, class: "text-area__form"
+        
+        .menu-input__btn
+          .menu-input__btn--submit
+            = f.submit "投稿する", class: "submit-btn"
+          .menu-input__btn--return
+            = link_to root_path, class: "return-btn" do
+              戻る

--- a/app/views/menus/new.html.haml
+++ b/app/views/menus/new.html.haml
@@ -18,6 +18,11 @@
           .menu-input__photobox--detail
             ※サムネイルにも使われます
           .menu-input__photobox__main
+            #photo-field
+              #photo-preview
+                - if @menu.persisted?
+                  = image_tag @menu.photo.url, width: "100px", height: "100px"
+                = f.file_field :photo, class: "js-file__menu"
 
         -# 情報入力部分
         .menu-input__menuname

--- a/app/views/menus/new.html.haml
+++ b/app/views/menus/new.html.haml
@@ -1,0 +1,55 @@
+-# ヘッダー部分
+= render partial: "shared/header"
+
+.menu
+  .menu-page
+    .menu-form
+      .menu-form__title
+        メニュー情報入力
+    .menu-input
+      = form_with model: @menu do |f|
+
+        -# 画像投稿部分
+        .menu-input__photobox
+          .menu-input__photobox--title
+            ・メニュー写真（１枚のみ）
+            .input-required
+              必須
+          .menu-input__photobox--detail
+            ※サムネイルにも使われます
+          .menu-input__photobox__main
+
+        -# 情報入力部分
+        .menu-input__menuname
+          .menu-input__menuname--title
+            ・メニュー名
+            .input-required
+              必須
+          .menu-input__menuname--field
+            = f.text_field :menuname, class: "text-field__form", placeholder: "例：生姜焼き定食"
+        
+        .menu-input__price
+          .menu-input__price--title
+            ・商品価格
+            .input-required
+              必須
+          .menu-input__price--field
+            = f.text_field :price, class: "text-field__form", placeholder: "例：1000円"
+
+        .menu-input__details
+          .menu-input__details--title
+            ・おすすめポイント
+            .input-any
+              任意
+          .menu-input__details--field
+            = f.text_area :detail, class: "text-area__form"
+        
+        .menu-input__btn
+          .menu-input__btn--submit
+            = f.submit "投稿する", class: "submit-btn"
+          .menu-input__btn--return
+            = link_to root_path, class: "return-btn" do
+              戻る
+
+-# フッター部分
+= render partial: "shared/footer"

--- a/app/views/menus/new.html.haml
+++ b/app/views/menus/new.html.haml
@@ -1,60 +1,8 @@
 -# ヘッダー部分
 = render partial: "shared/header"
 
-.menu
-  .menu-page
-    .menu-form
-      .menu-form__title
-        メニュー情報入力
-    .menu-input
-      = form_with model: @menu do |f|
-
-        -# 画像投稿部分
-        .menu-input__photobox
-          .menu-input__photobox--title
-            ・メニュー写真（１枚のみ）
-            .input-required
-              必須
-          .menu-input__photobox--detail
-            ※サムネイルにも使われます
-          .menu-input__photobox__main
-            #photo-field
-              #photo-preview
-                - if @menu.persisted?
-                  = image_tag @menu.photo.url, width: "100px", height: "100px"
-                = f.file_field :photo, class: "js-file__menu"
-
-        -# 情報入力部分
-        .menu-input__menuname
-          .menu-input__menuname--title
-            ・メニュー名
-            .input-required
-              必須
-          .menu-input__menuname--field
-            = f.text_field :menuname, class: "text-field__form", placeholder: "例：生姜焼き定食"
-        
-        .menu-input__price
-          .menu-input__price--title
-            ・商品価格
-            .input-required
-              必須
-          .menu-input__price--field
-            = f.text_field :price, class: "text-field__form", placeholder: "例：1000円"
-
-        .menu-input__details
-          .menu-input__details--title
-            ・おすすめポイント
-            .input-any
-              任意
-          .menu-input__details--field
-            = f.text_area :detail, class: "text-area__form"
-        
-        .menu-input__btn
-          .menu-input__btn--submit
-            = f.submit "投稿する", class: "submit-btn"
-          .menu-input__btn--return
-            = link_to root_path, class: "return-btn" do
-              戻る
+-# 投稿フォーム部分
+= render partial: "form"
 
 -# フッター部分
 = render partial: "shared/footer"

--- a/app/views/restaurants/show.html.haml
+++ b/app/views/restaurants/show.html.haml
@@ -101,10 +101,6 @@
               = link_to restaurant_path(@restaurant), class: "show-link", method: :delete do
                 .restaurant-info__action__btns__delete--text
                   削除する
-            .restaurant-info__action__btns__return
-              = link_to root_path, class: "show-link" do
-                .restaurant-info__action__btns__return--text
-                  戻る
         - else
           
       - else
@@ -127,7 +123,7 @@
         - if user_signed_in?
           - if @restaurant.user_id == current_user.id
             .restaurant-info__menus__btns__post
-              =link_to new_menu_path, class: "show-link" do
+              =link_to new_restaurant_menu_path(@restaurant), class: "show-link" do
                 .restaurant-info__menus__btns__post--text
                   メニューを投稿する
             .restaurant-info__menus__btns__return

--- a/app/views/restaurants/show.html.haml
+++ b/app/views/restaurants/show.html.haml
@@ -59,7 +59,7 @@
               %th 定休日
               %td.restaurant-info__exibition__box--content
                 = @restaurant.holiday
-          -# %tr
+          -# %tr 評価部分は未実装のため、コメントアウト中
           -#   %th 評価
           -#   %td.restaurant-info__exibition__box--content
           %tr
@@ -106,17 +106,8 @@
                 .restaurant-info__action__btns__return--text
                   戻る
         - else
-          .restaurant-info__action__btns
-            .restaurant-info__action__btns__return
-              = link_to root_path, class: "show-link" do
-                .restaurant-info__action__btns__return--text
-                  戻る
+          
       - else
-        .restaurant-info__action__btns
-          .restaurant-info__action__btns__return
-            = link_to root_path, class: "show-link" do
-              .restaurant-info__action__btns__return--text
-                戻る
     
     -# メニュー一覧表示部分
     .restaurant-info__menus
@@ -134,9 +125,9 @@
       -# メニュー投稿・戻るボタン部分
       .restaurant-info__menus__btns
         - if user_signed_in?
-          - if @restaurant.user_id = current_user.id
+          - if @restaurant.user_id == current_user.id
             .restaurant-info__menus__btns__post
-              =link_to "#", class: "show-link" do
+              =link_to new_menu_path, class: "show-link" do
                 .restaurant-info__menus__btns__post--text
                   メニューを投稿する
             .restaurant-info__menus__btns__return

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,12 @@ Rails.application.routes.draw do
   devise_for :users
   
   root "restaurants#index"
-  resources :restaurants
-  
-  resources :menus
-
+  resources :restaurants do
+    resources :menus do
+      collection do
+        post "/restaurants/menus/create", to: "menus#create"
+    end
+  end
+end
   resources :users, only: [:show, :edit, :update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   
   root "restaurants#index"
   resources :restaurants
+  
+  resources :menus
 
   resources :users, only: [:show, :edit, :update]
 end

--- a/db/migrate/20200418114011_create_menus.rb
+++ b/db/migrate/20200418114011_create_menus.rb
@@ -1,0 +1,8 @@
+class CreateMenus < ActiveRecord::Migration[5.2]
+  def change
+    create_table :menus do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200418114011_create_menus.rb
+++ b/db/migrate/20200418114011_create_menus.rb
@@ -1,6 +1,12 @@
 class CreateMenus < ActiveRecord::Migration[5.2]
   def change
     create_table :menus do |t|
+      t.string     :menuname, null: false
+      t.string     :photo
+      t.integer    :price, null: false
+      t.string     :detail
+      t.references :restaurant, null: false, foreign_key:true
+      t.references :user, null: false, foreign_key:true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_15_005020) do
+ActiveRecord::Schema.define(version: 2020_04_18_114011) do
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "image"
@@ -18,6 +18,19 @@ ActiveRecord::Schema.define(version: 2020_04_15_005020) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["restaurant_id"], name: "index_images_on_restaurant_id"
+  end
+
+  create_table "menus", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "menuname", null: false
+    t.string "photo"
+    t.integer "price", null: false
+    t.string "detail"
+    t.bigint "restaurant_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["restaurant_id"], name: "index_menus_on_restaurant_id"
+    t.index ["user_id"], name: "index_menus_on_user_id"
   end
 
   create_table "restaurants", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -55,5 +68,7 @@ ActiveRecord::Schema.define(version: 2020_04_15_005020) do
   end
 
   add_foreign_key "images", "restaurants"
+  add_foreign_key "menus", "restaurants"
+  add_foreign_key "menus", "users"
   add_foreign_key "restaurants", "users"
 end

--- a/spec/controllers/menus_controller_spec.rb
+++ b/spec/controllers/menus_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MenusController, type: :controller do
+
+end

--- a/spec/factories/menus.rb
+++ b/spec/factories/menus.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :menu do
+    
+  end
+end

--- a/spec/models/menu_spec.rb
+++ b/spec/models/menu_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Menu, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## What
メニューの投稿機能を実装する。

## Why
ユーザーにお気に入りのメニューを店舗情報と紐づけて投稿してもらうため。

実装について
- menuモデルを作成。
- menusテーブルを作成。
- menus_controllerを作成。newアクションを記述。
- menusモデルにアソシエーションとバリデーションを記述。
- rootをrestaurantsにネスト。createアクションのパスをカスタマイズ。
- new.html.hamlをmenusフォルダに作成。内容記述。
- new.scssをmenusフォルダに作成。内容記述。
- createアクション、内容記述。