### PR TITLE
メニュー情報削除機能

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -15,7 +15,6 @@ class MenusController < ApplicationController
   end
 
   def show
-    
   end
 
   def destroy

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,7 +1,7 @@
 class MenusController < ApplicationController
+  before_action :set_menu, only:[:show, :destroy]
 
   def new
-    @restaurant = Restaurant.find(params[:restaurant_id])
     @menu = Menu.new
   end
 
@@ -15,12 +15,24 @@ class MenusController < ApplicationController
   end
 
   def show
-    @menu = Menu.find(params[:id])
+    
+  end
+
+  def destroy
+    if @menu.destroy
+      redirect_to root_path
+    else
+      redirect_to menu_path
+    end
   end
 
   private
 
     def menu_params
       params.require(:menu).permit(:menuname, :photo, :price, :detail).merge(user_id: current_user.id, restaurant_id: params[:restaurant_id])
+    end
+
+    def set_menu
+      @menu = Menu.find(params[:id])
     end
 end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -4,10 +4,9 @@ class Restaurant < ApplicationRecord
     belongs_to_active_hash :cuisine
 
   belongs_to :user
+  has_many :menus, dependent: :destroy
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true
-  has_many :menus, dependent: :destroy
-  accepts_nested_attributes_for :menus
 
   validates :name, presence: true
   validates :cuisine_id, presence: true

--- a/app/views/menus/new.html.haml
+++ b/app/views/menus/new.html.haml
@@ -8,7 +8,7 @@
       .menu-form__title
         メニュー情報入力
     .menu-input
-      = form_with model: @menu, url: restaurants_menus_create_restaurant_menus_path ,mehtod: :post, action: :create, local: true do |f|
+      = form_with model: [@restaurant, @menu], url: restaurant_menus_path ,mehtod: :post, action: :create, local: true do |f|
 
         -# 画像投稿部分
         .menu-input__photobox

--- a/app/views/menus/show.html.haml
+++ b/app/views/menus/show.html.haml
@@ -41,7 +41,7 @@
         - if @menu.user_id == current_user.id
           .menu-info__action__btns
             .menu-info__action__btns__delete
-              = link_to "#", class: "show-link" do
+              = link_to menu_path(@menu.id), class: "show-link", method: :delete do
                 .menu-info__action__btns__delete--text
                   削除する
             .menu-info__action__btns__return

--- a/app/views/shared/_menuindex.html.haml
+++ b/app/views/shared/_menuindex.html.haml
@@ -1,5 +1,5 @@
 .menu-box
-  = link_to menu_path(menu_url= 1) do
+  = link_to menu_path(menu_url=2) do
     .menu-box__contents
       .menu-box__contents--photo
         = image_tag "nodata.jpg", width: "150px", height: "100px", class: "menu-photo"

--- a/app/views/shared/_menuindex.html.haml
+++ b/app/views/shared/_menuindex.html.haml
@@ -1,5 +1,5 @@
 .menu-box
-  = link_to restaurant_menu_path(menu_url=4) do
+  = link_to menu_path(menu_url= 1) do
     .menu-box__contents
       .menu-box__contents--photo
         = image_tag "nodata.jpg", width: "150px", height: "100px", class: "menu-photo"
@@ -7,4 +7,4 @@
         .menu-box__contents__detail--name
           生姜焼き定食
         .menu-box__contents__detail--price
-          ¥ 1900
+          1990円

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,11 +4,8 @@ Rails.application.routes.draw do
   
   root "restaurants#index"
   resources :restaurants do
-    resources :menus do
-      collection do
-        post "/restaurants/menus/create", to: "menus#create"
-    end
+    resources :menus, shallow: true
   end
-end
+
   resources :users, only: [:show, :edit, :update]
 end


### PR DESCRIPTION
## What
メニュー情報の削除機能実装。

## Why
メニュー情報の削除を行うため。

実装について
- menusルートに、shallow: trueを追加。
- menuindexのlink_toパスの記述を変更。
- menus/showの削除ボタンにdeleteメソッドを追加。
- menusコントローラーに、destroyアクションを追加。private以下にset_menuを設定。before_actionでshowとdestroyに付加。
- menus/newのモデルとurlのパスを変更。
- menuモデルのaccept_nested_attributes_for :menusを削除。