### PR TITLE
メニュー一覧表示機能

### DIFF
--- a/app/assets/stylesheets/restaurants/show.scss
+++ b/app/assets/stylesheets/restaurants/show.scss
@@ -175,6 +175,28 @@
       &__index {
         padding: 10px 0;
       }
+
+      &__paginations {
+        padding-top: 10px;
+        font-size: 25px;
+      }
+
+      .pagination {
+        text-align: center;
+      }
+
+      &__nodata {
+        height: 55px;
+        width: 550px;
+        background-color: palevioletred;
+        margin: 170px 0 0 25px;
+
+        &--text {
+          color: white;
+          font-size: 35px;
+          text-align: center;
+        }
+      }
     }
 
     // メニュー用ボタン部分

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -20,6 +20,7 @@ class RestaurantsController < ApplicationController
   end
 
   def show
+    @menus = Menu.where(restaurant_id: @restaurant).page(params[:page]).per(3).order("created_at DESC")
   end
 
   def edit

--- a/app/views/restaurants/show.html.haml
+++ b/app/views/restaurants/show.html.haml
@@ -113,9 +113,15 @@
           .restaurant-info__menus__box__title--text
             メニュー
         .restaurant-info__menus__box__index
-          = render partial: "shared/menuindex"
-          = render partial: "shared/menuindex"
-          = render partial: "shared/menuindex"
+          - if @menus.present?
+            - @menus.each do |menu|
+              = render partial: "shared/menuindex", locals: {menu: menu}
+            .restaurant-info__menus__box__paginations
+              = paginate(@menus)
+          - else
+            .restaurant-info__menus__box__nodata
+              .restaurant-info__menus__box__nodata--text
+                投稿がありません
 
       -# メニュー投稿・戻るボタン部分
       .restaurant-info__menus__btns

--- a/app/views/shared/_menuindex.html.haml
+++ b/app/views/shared/_menuindex.html.haml
@@ -1,10 +1,13 @@
 .menu-box
-  = link_to menu_path(menu_url=2) do
+  = link_to menu_path(menu.id) do
     .menu-box__contents
       .menu-box__contents--photo
-        = image_tag "nodata.jpg", width: "150px", height: "100px", class: "menu-photo"
+        - if menu.photo.present?
+          = image_tag "#{menu.photo}", width: "150px", height: "100px", class: "menu-photo"
+        - else
+          = image_tag "nodata.jpg",  width: "150px", height: "100px", class: "menu-photo"
       .menu-box__contents__detail
         .menu-box__contents__detail--name
-          生姜焼き定食
+          #{menu.menuname}
         .menu-box__contents__detail--price
-          1990円
+          #{menu.price}円

--- a/config/locales/kaminari.ja.yml
+++ b/config/locales/kaminari.ja.yml
@@ -1,0 +1,17 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "&hellip;"
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: "%{entry_name}がありません"
+          one: "<b>一つの</b>%{entry_name}しか表示されていません"
+          other: "他<b>%{count}</b>個の%{entry_name}が表示されています"
+      more_pages:
+        display_entries: "<b>%{first}&nbsp;-&nbsp;%{last}</b> 全部<b>%{total}</b>個の%{entry_name}が表示されています"


### PR DESCRIPTION
## What
投稿されたメニューの一覧表示を行う。

## Why
投稿された飲食店のメニューの一覧表示を行いユーザーに認知してもらうため。

実装について
- restaurantsコントローラー、showアクションに@menusメソッドを追加。
- restaurants/showビューにて、一覧表示を行うeach文と部分テンプレートの記述。
- @menusの情報がない場合は、if文にて分岐。「投稿がありません」とビューを表示。
- ページネーションを実装し、cssを追加。
- 投稿がない場合のsccを追加。
- 部分テンプレート、menuindex内の情報を仮置きから、レコード情報取得メソッドへ変更。
- kaminariを日本語化。config/localsにkaminari.ja.ymlを追加。